### PR TITLE
Fix deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Build and Deploy
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
You have a new GitHub repository. They default to `main`. Currently, your CI won't work because it isn't triggered.